### PR TITLE
Links de línguas podem ser adicionados via actions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,10 @@ Histórico de Alterações
 1.0.8 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Adicionada nova regra permitindo a inserção de uma div de língua num produto
-  de policy ou numa customização da ZMI sem precisar customizar o tema.
+- Adicionada estrutura nas regras de Diazo permitindo inserção de links de
+  línguas como actions em "site_actions": basta criar com o mesmo id hoje
+  presente nas regras css (language-en e language-es). Dessa forma, evita-se
+  customização do tema apenas para inserção desses links.
   [idgserpro]
 
 

--- a/README.rst
+++ b/README.rst
@@ -85,3 +85,8 @@ buildout:
 
 4. Acesse o painel de controle e na opção **Temas** você verá os temas
 providos por este pacote listados.
+
+Links de línguas no topo (Internacionalização)
+----------------------------------------------
+
+Hoje nos arquivos css existem regras para mostrar links de línguas, como as classes ``language-en`` e ``language-es``. Para adicionar links dessas línguas sem precisar customizar o tema, adicione em ``site_actions`` actions com esse mesmo id e as regras do Diazo pegarão os links renderizados das actions posicionando corretamente na lista de línguas no tema.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.0.8.dev1'
+version = '1.0.8.dev2'
 long_description = (
     open('README.rst').read() + '\n' +
     open('CONTRIBUTORS.rst').read() + '\n' +

--- a/src/brasil/gov/temas/themes/amarelo/index.html
+++ b/src/brasil/gov/temas/themes/amarelo/index.html
@@ -59,8 +59,8 @@
                         </a>
                     </li>
                 </ul>
-                <!--
-            <ul id="language">
+                
+            <ul id="language" class="hidden">
                 <li class="language-es">
                     <a href="#">Espa&#241;ol</a>
                 </li>
@@ -68,7 +68,7 @@
                     <a href="#">English</a>
                 </li>
             </ul>
-            -->
+            
             <ul id="portal-siteactions">
                 <li>
                     <a href="#">Acessibilidade</a>

--- a/src/brasil/gov/temas/themes/amarelo/rules.xml
+++ b/src/brasil/gov/temas/themes/amarelo/rules.xml
@@ -59,10 +59,27 @@
         <replace css:content-children="#portal-footer" css:theme="#footer-info" />
         <after css:content="#portal-languageselector" css:theme="#logo" />
         <drop css:content="#viewlet-below-content-body" />
-        <!-- Essa regra só é renderizada em portais multilíngues que adicionem
-             uma div de línguas podendo ser via viewlets ou mesmos customizações
-             na ZMI. -->
-        <after css:content="#language" css:theme="#accessibility" />
+
+        <!-- UL DE LíNGUAS
+        É necessário cadastrar uma action em site_actions com o mesmo id de
+        língua que existe no css, ou seja, no padrão "language-LANGUADE_CODE",
+        para que as regras a seguir funcionem corretamente.-->
+
+        <!--Habilita a div de línguas novamente removendo o hidden, já que encontrou uma action de-->
+        <!--língua renderizada.-->
+        <drop if-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="#language" attributes="class" />
+
+        <!-- Inglês -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-en')]" css:theme=".language-en" />
+        <copy attributes="href" css:content="#siteaction-language-en a" css:theme=".language-en a" />
+        <drop css:content="#siteaction-language-en" />
+
+        <!-- Espanhol -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
+        <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
+        <drop css:content="#siteaction-language-es" />
+        <!-- UL DE LíNGUAS -->
+
         <after theme-children="/html/body" css:content-children="#plone-analytics" />
 
     </rules>

--- a/src/brasil/gov/temas/themes/amarelo/rules.xml
+++ b/src/brasil/gov/temas/themes/amarelo/rules.xml
@@ -78,6 +78,10 @@
         <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
         <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
         <drop css:content="#siteaction-language-es" />
+
+        <!--Se não vier nenhuma action de língua, é necessário remover por completo-->
+        <!--a ul de línguas do tema pois ela estará vazia. -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="ul#language" />
         <!-- UL DE LíNGUAS -->
 
         <after theme-children="/html/body" css:content-children="#plone-analytics" />

--- a/src/brasil/gov/temas/themes/azul/index.html
+++ b/src/brasil/gov/temas/themes/azul/index.html
@@ -59,8 +59,8 @@
                         </a>
                     </li>
                 </ul>
-                <!--
-            <ul id="language">
+                
+            <ul id="language" class="hidden">
                 <li class="language-es">
                     <a href="#">Espa&#241;ol</a>
                 </li>
@@ -68,7 +68,7 @@
                     <a href="#">English</a>
                 </li>
             </ul>
-            -->
+            
             <ul id="portal-siteactions">
                 <li>
                     <a href="#">Acessibilidade</a>

--- a/src/brasil/gov/temas/themes/azul/rules.xml
+++ b/src/brasil/gov/temas/themes/azul/rules.xml
@@ -59,10 +59,27 @@
         <replace css:content-children="#portal-footer" css:theme="#footer-info" />
         <after css:content="#portal-languageselector" css:theme="#logo" />
         <drop css:content="#viewlet-below-content-body" />
-        <!-- Essa regra só é renderizada em portais multilíngues que adicionem
-             uma div de línguas podendo ser via viewlets ou mesmos customizações
-             na ZMI. -->
-        <after css:content="#language" css:theme="#accessibility" />
+
+        <!-- UL DE LíNGUAS
+        É necessário cadastrar uma action em site_actions com o mesmo id de
+        língua que existe no css, ou seja, no padrão "language-LANGUADE_CODE",
+        para que as regras a seguir funcionem corretamente.-->
+
+        <!--Habilita a div de línguas novamente removendo o hidden, já que encontrou uma action de-->
+        <!--língua renderizada.-->
+        <drop if-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="#language" attributes="class" />
+
+        <!-- Inglês -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-en')]" css:theme=".language-en" />
+        <copy attributes="href" css:content="#siteaction-language-en a" css:theme=".language-en a" />
+        <drop css:content="#siteaction-language-en" />
+
+        <!-- Espanhol -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
+        <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
+        <drop css:content="#siteaction-language-es" />
+        <!-- UL DE LíNGUAS -->
+
         <after theme-children="/html/body" css:content-children="#plone-analytics" />
 
     </rules>

--- a/src/brasil/gov/temas/themes/azul/rules.xml
+++ b/src/brasil/gov/temas/themes/azul/rules.xml
@@ -78,6 +78,10 @@
         <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
         <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
         <drop css:content="#siteaction-language-es" />
+
+        <!--Se não vier nenhuma action de língua, é necessário remover por completo-->
+        <!--a ul de línguas do tema pois ela estará vazia. -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="ul#language" />
         <!-- UL DE LíNGUAS -->
 
         <after theme-children="/html/body" css:content-children="#plone-analytics" />

--- a/src/brasil/gov/temas/themes/branco/index.html
+++ b/src/brasil/gov/temas/themes/branco/index.html
@@ -59,8 +59,8 @@
                         </a>
                     </li>
                 </ul>
-                <!--
-            <ul id="language">
+                
+            <ul id="language" class="hidden">
                 <li class="language-es">
                     <a href="#">Espa&#241;ol</a>
                 </li>
@@ -68,7 +68,7 @@
                     <a href="#">English</a>
                 </li>
             </ul>
-            -->
+            
             <ul id="portal-siteactions">
                 <li>
                     <a href="#">Acessibilidade</a>

--- a/src/brasil/gov/temas/themes/branco/rules.xml
+++ b/src/brasil/gov/temas/themes/branco/rules.xml
@@ -59,10 +59,27 @@
         <replace css:content-children="#portal-footer" css:theme="#footer-info" />
         <after css:content="#portal-languageselector" css:theme="#logo" />
         <drop css:content="#viewlet-below-content-body" />
-        <!-- Essa regra só é renderizada em portais multilíngues que adicionem
-             uma div de línguas podendo ser via viewlets ou mesmos customizações
-             na ZMI. -->
-        <after css:content="#language" css:theme="#accessibility" />
+
+        <!-- UL DE LíNGUAS
+        É necessário cadastrar uma action em site_actions com o mesmo id de
+        língua que existe no css, ou seja, no padrão "language-LANGUADE_CODE",
+        para que as regras a seguir funcionem corretamente.-->
+
+        <!--Habilita a div de línguas novamente removendo o hidden, já que encontrou uma action de-->
+        <!--língua renderizada.-->
+        <drop if-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="#language" attributes="class" />
+
+        <!-- Inglês -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-en')]" css:theme=".language-en" />
+        <copy attributes="href" css:content="#siteaction-language-en a" css:theme=".language-en a" />
+        <drop css:content="#siteaction-language-en" />
+
+        <!-- Espanhol -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
+        <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
+        <drop css:content="#siteaction-language-es" />
+        <!-- UL DE LíNGUAS -->
+
         <after theme-children="/html/body" css:content-children="#plone-analytics" />
 
     </rules>

--- a/src/brasil/gov/temas/themes/branco/rules.xml
+++ b/src/brasil/gov/temas/themes/branco/rules.xml
@@ -78,6 +78,10 @@
         <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
         <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
         <drop css:content="#siteaction-language-es" />
+
+        <!--Se não vier nenhuma action de língua, é necessário remover por completo-->
+        <!--a ul de línguas do tema pois ela estará vazia. -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="ul#language" />
         <!-- UL DE LíNGUAS -->
 
         <after theme-children="/html/body" css:content-children="#plone-analytics" />

--- a/src/brasil/gov/temas/themes/verde/index.html
+++ b/src/brasil/gov/temas/themes/verde/index.html
@@ -59,8 +59,8 @@
                         </a>
                     </li>
                 </ul>
-                <!--
-            <ul id="language">
+                
+            <ul id="language" class="hidden">
                 <li class="language-es">
                     <a href="#">Espa&#241;ol</a>
                 </li>
@@ -68,7 +68,7 @@
                     <a href="#">English</a>
                 </li>
             </ul>
-            -->
+            
             <ul id="portal-siteactions">
                 <li>
                     <a href="#">Acessibilidade</a>

--- a/src/brasil/gov/temas/themes/verde/rules.xml
+++ b/src/brasil/gov/temas/themes/verde/rules.xml
@@ -59,10 +59,27 @@
         <replace css:content-children="#portal-footer" css:theme="#footer-info" />
         <after css:content="#portal-languageselector" css:theme="#logo" />
         <drop css:content="#viewlet-below-content-body" />
-        <!-- Essa regra só é renderizada em portais multilíngues que adicionem
-             uma div de línguas podendo ser via viewlets ou mesmos customizações
-             na ZMI. -->
-        <after css:content="#language" css:theme="#accessibility" />
+
+        <!-- UL DE LíNGUAS
+        É necessário cadastrar uma action em site_actions com o mesmo id de
+        língua que existe no css, ou seja, no padrão "language-LANGUADE_CODE",
+        para que as regras a seguir funcionem corretamente.-->
+
+        <!--Habilita a div de línguas novamente removendo o hidden, já que encontrou uma action de-->
+        <!--língua renderizada.-->
+        <drop if-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="#language" attributes="class" />
+
+        <!-- Inglês -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-en')]" css:theme=".language-en" />
+        <copy attributes="href" css:content="#siteaction-language-en a" css:theme=".language-en a" />
+        <drop css:content="#siteaction-language-en" />
+
+        <!-- Espanhol -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
+        <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
+        <drop css:content="#siteaction-language-es" />
+        <!-- UL DE LíNGUAS -->
+
         <after theme-children="/html/body" css:content-children="#plone-analytics" />
 
     </rules>

--- a/src/brasil/gov/temas/themes/verde/rules.xml
+++ b/src/brasil/gov/temas/themes/verde/rules.xml
@@ -78,6 +78,10 @@
         <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-es')]" css:theme=".language-es" />
         <copy attributes="href" css:content="#siteaction-language-es a" css:theme=".language-es a" />
         <drop css:content="#siteaction-language-es" />
+
+        <!--Se não vier nenhuma action de língua, é necessário remover por completo-->
+        <!--a ul de línguas do tema pois ela estará vazia. -->
+        <drop if-not-content="//ul[@id='portal-siteactions']/li[contains(@id,'siteaction-language-')]" css:theme="ul#language" />
         <!-- UL DE LíNGUAS -->
 
         <after theme-children="/html/body" css:content-children="#plone-analytics" />


### PR DESCRIPTION
Adicionada estrutura nas regras de Diazo permitindo inserção de links de
línguas como actions em "site_actions": basta criar com o mesmo id hoje
presente nas regras css (language-en e language-es). Dessa forma, evita-se
customização do tema apenas para inserção desses links.

Essa modificação é mais eficiente que a apresentada no commit https://github.com/plonegovbr/brasil.gov.temas/commit/843e87f4b433dacd528dd23176bbbbb1b32a84c9
pois não necessita de modificações adicionais nem de criação de viewlets
auxiliares, basta utilizar a infra-estrutura hoje existente de actions.

As actions podem ser incluídas diretamente pela ZMI ou mesmo através de um pacote de policy via actions.xml.