### PR TITLE
Corrigi 'Preferencias pessoais' que não aparecia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Makefile
 parts/
 src/collective.cover/
 var/
+/dist/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,12 +4,13 @@ Histórico de Alterações
 1.0.8 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-- Adicionadas regras para inserir as traduções das viewlets de copyright do
+* Corrigi erro em que a tela de 'Preferências Pessoais' aparecia vazia. (closes `#113`_)
+  [idgserpro]
+* Adicionadas regras para inserir as traduções das viewlets de copyright do
   Plone, "Voltar para o topo" e seção de acessibilidade de brasil.gov.portal
   no tema.
   [idgserpro]
-
-- Adicionada estrutura nas regras de Diazo permitindo inserção de links de
+* Adicionada estrutura nas regras de Diazo permitindo inserção de links de
   línguas como actions em "site_actions": basta criar com o mesmo id hoje
   presente nas regras css (language-en e language-es). Dessa forma, evita-se
   customização do tema apenas para inserção desses links.
@@ -246,3 +247,4 @@ Histórico de Alterações
 .. _`#101`: https://github.com/plonegovbr/brasil.gov.temas/issues/101
 .. _`#103`: https://github.com/plonegovbr/brasil.gov.temas/issues/103
 .. _`#106`: https://github.com/plonegovbr/brasil.gov.temas/issues/106
+.. _`#113`: https://github.com/plonegovbr/brasil.gov.temas/issues/113

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Histórico de Alterações
 1.0.8 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
-* Corrigi erro em que a tela de 'Preferências Pessoais' aparecia vazia. (closes `#113`_)
+* Corrigi erro em que as telas de 'Preferências Pessoais', 'Informação Pessoal'
+  e 'Painel Pessoal' apareciam vazias. (closes `#113`_)
   [idgserpro]
 * Adicionadas regras para inserir as traduções das viewlets de copyright do
   Plone, "Voltar para o topo" e seção de acessibilidade de brasil.gov.portal

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -27,3 +27,8 @@ eggs = i18ndude
 [omelette]
 recipe = collective.recipe.omelette
 eggs = ${test:eggs}
+
+[versions]
+# Necessário colocar o pacote com versão vazia para que outras versões no
+# buildout-cache não sobrescrevam o próprio pacote.
+brasil.gov.temas =

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages
 from setuptools import setup
 
-version = '1.0.8.dev2'
+version = '1.0.8.dev3'
 long_description = (
     open('README.rst').read() + '\n' +
     open('CONTRIBUTORS.rst').read() + '\n' +

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
+        'brasil.gov.portal',
         'Products.CMFPlone >=4.3',
         'setuptools',
         'plone.app.themingplugins',
@@ -51,7 +52,6 @@ setup(
     extras_require={
         'test': [
             'plone.app.testing',
-            'brasil.gov.portal',
         ]
     },
     entry_points="""

--- a/src/brasil/gov/temas/tests/tests_funcionais.py
+++ b/src/brasil/gov/temas/tests/tests_funcionais.py
@@ -9,7 +9,6 @@ from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from zope.component import getUtility
 
-import base64
 import Globals
 import unittest
 
@@ -29,10 +28,7 @@ class TransformsTestCase(unittest.TestCase):
         """Autentica usuário de teste no browser"""
         browser.handleErrors = False
         basic_auth = 'Basic {0}'.format(
-            base64.encodestring('{0}:{1}'.format(
-                SITE_OWNER_NAME,
-                SITE_OWNER_PASSWORD)
-            )
+            '{0}:{1}'.format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         )
         browser.addHeader('Authorization', basic_auth)
 

--- a/src/brasil/gov/temas/tests/tests_funcionais.py
+++ b/src/brasil/gov/temas/tests/tests_funcionais.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from brasil.gov.temas.testing import FUNCTIONAL_TESTING
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.app.theming.interfaces import IThemeSettings
 from plone.app.theming.utils import applyTheme
 from plone.app.theming.utils import getTheme
@@ -7,6 +9,7 @@ from plone.registry.interfaces import IRegistry
 from plone.testing.z2 import Browser
 from zope.component import getUtility
 
+import base64
 import Globals
 import unittest
 
@@ -21,6 +24,17 @@ class TransformsTestCase(unittest.TestCase):
         self.settings = getUtility(IRegistry).forInterface(IThemeSettings)
         import transaction
         transaction.commit()
+
+    def login_browser(self, browser):
+        """Autentica usuário de teste no browser"""
+        browser.handleErrors = False
+        basic_auth = 'Basic {0}'.format(
+            base64.encodestring('{0}:{1}'.format(
+                SITE_OWNER_NAME,
+                SITE_OWNER_PASSWORD)
+            )
+        )
+        browser.addHeader('Authorization', basic_auth)
 
     def test_tema_verde(self):
         theme = getTheme('verde')
@@ -81,3 +95,107 @@ class TransformsTestCase(unittest.TestCase):
 
         # Removido logo do governo federal
         self.assertIn("brasil.png", browser.contents)
+
+    def test_tema_verde_autenticado(self):
+        theme = getTheme('verde')
+        applyTheme(theme)
+        self.settings.enabled = True
+        import transaction
+        transaction.commit()
+        browser = Browser(self.layer['app'])
+        self.login_browser(browser)
+
+        # Testa se elementos do dashboard aparecem.
+        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('dashboard</h1>', browser.contents)
+
+        # Testa se elementos da 'Informação Pessoal' aparecem.
+        browser.open('{0}/@@user-information?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Change your personal information', browser.contents)
+
+        # Testa se elementos da 'Preferências Pessoais' aparecem.
+        browser.open('{0}/@@user-preferences?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Your personal settings', browser.contents)
+
+    def test_tema_amarelo_autenticado(self):
+        theme = getTheme('amarelo')
+        applyTheme(theme)
+        self.settings.enabled = True
+        import transaction
+        transaction.commit()
+        browser = Browser(self.layer['app'])
+        self.login_browser(browser)
+
+        # Testa se elementos do dashboard aparecem.
+        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('dashboard</h1>', browser.contents)
+
+        # Testa se elementos da 'Informação Pessoal' aparecem.
+        browser.open('{0}/@@user-information?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Change your personal information', browser.contents)
+
+        # Testa se elementos da 'Preferências Pessoais' aparecem.
+        browser.open('{0}/@@user-preferences?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Your personal settings', browser.contents)
+
+    def test_tema_branco_autenticado(self):
+        theme = getTheme('branco')
+        applyTheme(theme)
+        self.settings.enabled = True
+        import transaction
+        transaction.commit()
+        browser = Browser(self.layer['app'])
+        self.login_browser(browser)
+
+        # Testa se elementos do dashboard aparecem.
+        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('dashboard</h1>', browser.contents)
+
+        # Testa se elementos da 'Informação Pessoal' aparecem.
+        browser.open('{0}/@@user-information?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Change your personal information', browser.contents)
+
+        # Testa se elementos da 'Preferências Pessoais' aparecem.
+        browser.open('{0}/@@user-preferences?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Your personal settings', browser.contents)
+
+    def test_tema_azul_autenticado(self):
+        theme = getTheme('azul')
+        applyTheme(theme)
+        self.settings.enabled = True
+        import transaction
+        transaction.commit()
+        browser = Browser(self.layer['app'])
+        self.login_browser(browser)
+
+        # Testa se elementos do dashboard aparecem.
+        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('dashboard</h1>', browser.contents)
+
+        # Testa se elementos da 'Informação Pessoal' aparecem.
+        browser.open('{0}/@@user-information?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Change your personal information', browser.contents)
+
+        # Testa se elementos da 'Preferências Pessoais' aparecem.
+        browser.open('{0}/@@user-preferences?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', browser.contents)
+        self.assertIn('Your personal settings', browser.contents)

--- a/src/brasil/gov/temas/tests/tests_funcionais.py
+++ b/src/brasil/gov/temas/tests/tests_funcionais.py
@@ -21,177 +21,94 @@ class TransformsTestCase(unittest.TestCase):
         Globals.DevelopmentMode = True
         self.portal = self.layer['portal']
         self.settings = getUtility(IRegistry).forInterface(IThemeSettings)
+        self.browser = Browser(self.layer['app'])
         import transaction
         transaction.commit()
 
-    def login_browser(self, browser):
+    def base_test(self, cor):
+        """Teste base dos temas"""
+        theme = getTheme(cor)
+        applyTheme(theme)
+        self.settings.enabled = True
+        import transaction
+        transaction.commit()
+        self.browser.open(self.portal.absolute_url())
+
+        # Acesso a Informacao deve estar disponivel
+        self.assertIn("acesso-a-infornacao.png", self.browser.contents)
+
+        # Removido logo do governo federal
+        self.assertIn("brasil.png", self.browser.contents)
+
+    def test_tema_verde(self):
+        self.base_test('verde')
+
+    def test_tema_amarelo(self):
+        self.base_test('amarelo')
+
+    def test_tema_branco(self):
+        self.base_test('branco')
+
+    def test_tema_azul(self):
+        self.base_test('azul')
+
+
+class AuthenticatedTestCase(unittest.TestCase):
+    """Teste funcionais com usuário autenticado"""
+
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        Globals.DevelopmentMode = True
+        self.portal = self.layer['portal']
+        self.settings = getUtility(IRegistry).forInterface(IThemeSettings)
+        self.browser = Browser(self.layer['app'])
+        self.login_browser()
+        import transaction
+        transaction.commit()
+
+    def login_browser(self):
         """Autentica usuário de teste no browser"""
-        browser.handleErrors = False
+        self.browser.handleErrors = False
         basic_auth = 'Basic {0}'.format(
             '{0}:{1}'.format(SITE_OWNER_NAME, SITE_OWNER_PASSWORD)
         )
-        browser.addHeader('Authorization', basic_auth)
+        self.browser.addHeader('Authorization', basic_auth)
 
-    def test_tema_verde(self):
-        theme = getTheme('verde')
+    def base_test(self, cor):
+        """Teste base dos temas"""
+        theme = getTheme(cor)
         applyTheme(theme)
         self.settings.enabled = True
         import transaction
         transaction.commit()
-        browser = Browser(self.layer['app'])
-        browser.open(self.portal.absolute_url())
 
-        # Acesso a Informacao deve estar disponivel
-        self.assertIn("acesso-a-infornacao.png", browser.contents)
+        # Testa se elementos do dashboard aparecem.
+        self.browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', self.browser.contents)
+        self.assertIn('dashboard</h1>', self.browser.contents)
 
-        # Removido logo do governo federal
-        self.assertIn("brasil.png", browser.contents)
+        # Testa se elementos da 'Informação Pessoal' aparecem.
+        self.browser.open('{0}/@@user-information?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', self. browser.contents)
+        self.assertIn('Change your personal information',
+                      self.browser.contents)
 
-    def test_tema_amarelo(self):
-        theme = getTheme('amarelo')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        browser.open(self.portal.absolute_url())
-
-        # Acesso a Informacao deve estar disponivel
-        self.assertIn("acesso-a-infornacao.png", browser.contents)
-
-        # Removido logo do governo federal
-        self.assertIn("brasil.png", browser.contents)
-
-    def test_tema_branco(self):
-        theme = getTheme('branco')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        browser.open(self.portal.absolute_url())
-
-        # Acesso a Informacao deve estar disponivel
-        self.assertIn("acesso-a-infornacao.png", browser.contents)
-
-        # Removido logo do governo federal
-        self.assertIn("brasil.png", browser.contents)
-
-    def test_tema_azul(self):
-        theme = getTheme('azul')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        browser.open(self.portal.absolute_url())
-
-        # Acesso a Informacao deve estar disponivel
-        self.assertIn("acesso-a-infornacao.png", browser.contents)
-
-        # Removido logo do governo federal
-        self.assertIn("brasil.png", browser.contents)
+        # Testa se elementos da 'Preferências Pessoais' aparecem.
+        self.browser.open('{0}/@@user-preferences?userid=admin'.format(
+            self.portal.absolute_url()))
+        self.assertIn('id="kssPortalMessage"', self.browser.contents)
+        self.assertIn('Your personal settings', self.browser.contents)
 
     def test_tema_verde_autenticado(self):
-        theme = getTheme('verde')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        self.login_browser(browser)
-
-        # Testa se elementos do dashboard aparecem.
-        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('dashboard</h1>', browser.contents)
-
-        # Testa se elementos da 'Informação Pessoal' aparecem.
-        browser.open('{0}/@@user-information?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Change your personal information', browser.contents)
-
-        # Testa se elementos da 'Preferências Pessoais' aparecem.
-        browser.open('{0}/@@user-preferences?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Your personal settings', browser.contents)
+        self.base_test('verde')
 
     def test_tema_amarelo_autenticado(self):
-        theme = getTheme('amarelo')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        self.login_browser(browser)
-
-        # Testa se elementos do dashboard aparecem.
-        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('dashboard</h1>', browser.contents)
-
-        # Testa se elementos da 'Informação Pessoal' aparecem.
-        browser.open('{0}/@@user-information?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Change your personal information', browser.contents)
-
-        # Testa se elementos da 'Preferências Pessoais' aparecem.
-        browser.open('{0}/@@user-preferences?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Your personal settings', browser.contents)
+        self.base_test('amarelo')
 
     def test_tema_branco_autenticado(self):
-        theme = getTheme('branco')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        self.login_browser(browser)
-
-        # Testa se elementos do dashboard aparecem.
-        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('dashboard</h1>', browser.contents)
-
-        # Testa se elementos da 'Informação Pessoal' aparecem.
-        browser.open('{0}/@@user-information?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Change your personal information', browser.contents)
-
-        # Testa se elementos da 'Preferências Pessoais' aparecem.
-        browser.open('{0}/@@user-preferences?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Your personal settings', browser.contents)
+        self.base_test('branco')
 
     def test_tema_azul_autenticado(self):
-        theme = getTheme('azul')
-        applyTheme(theme)
-        self.settings.enabled = True
-        import transaction
-        transaction.commit()
-        browser = Browser(self.layer['app'])
-        self.login_browser(browser)
-
-        # Testa se elementos do dashboard aparecem.
-        browser.open('{0}/dashboard'.format(self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('dashboard</h1>', browser.contents)
-
-        # Testa se elementos da 'Informação Pessoal' aparecem.
-        browser.open('{0}/@@user-information?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Change your personal information', browser.contents)
-
-        # Testa se elementos da 'Preferências Pessoais' aparecem.
-        browser.open('{0}/@@user-preferences?userid=admin'.format(
-            self.portal.absolute_url()))
-        self.assertIn('id="kssPortalMessage"', browser.contents)
-        self.assertIn('Your personal settings', browser.contents)
+        self.base_test('azul')

--- a/src/brasil/gov/temas/themes/amarelo/index.html
+++ b/src/brasil/gov/temas/themes/amarelo/index.html
@@ -304,7 +304,7 @@
             <div id="portal-column-content" class="cell width-1:2 position-1:4">
                 <a name="acontent" id="acontent"></a>
 
-                <div class="">
+                <div id="main-content" class="">
 
                     <div id="content">
 

--- a/src/brasil/gov/temas/themes/amarelo/rules.xml
+++ b/src/brasil/gov/temas/themes/amarelo/rules.xml
@@ -37,7 +37,17 @@
 	    <copy attributes="role" css:content="content" css:theme="contentspace" />
         <replace css:content="#portal-column-one" css:theme="#portal-column-one" />
         <replace css:content="#viewlet-above-content" css:theme="#viewlet-above-content" />
-        <replace content="//*[@id='portal-column-content']/div[2]" theme="//*[@id='portal-column-content']/div[1]" />
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        
+        <!-- Devem ser selecionados os filhos imediátos do #portal-column-content do conteúdo, para
+        que não sejam aplicados em templates que não sejam de gestão de usuários. Se as regras abaixo
+        forem aplicadas em templates que não sejam de gestão de usuários, o conteúdo ficará duplicado uma vez que a regra:
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        já insere esses ids no tema.-->
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #kssPortalMessage" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #dashboard-info-message" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #content" />
+
         <copy attributes="class" css:content="#portal-column-content" css:theme="#portal-column-content" />
         <replace css:content="#portal-column-content > #viewlet-below-content" css:theme="#portal-column-content > #viewlet-below-content" />
         <replace css:content="#portal-column-two" css:theme="#portal-column-two" />

--- a/src/brasil/gov/temas/themes/azul/index.html
+++ b/src/brasil/gov/temas/themes/azul/index.html
@@ -304,7 +304,7 @@
             <div id="portal-column-content" class="cell width-1:2 position-1:4">
                 <a name="acontent" id="acontent"></a>
 
-                <div class="">
+                <div id="main-content" class="">
 
                     <div id="content">
 

--- a/src/brasil/gov/temas/themes/azul/rules.xml
+++ b/src/brasil/gov/temas/themes/azul/rules.xml
@@ -37,7 +37,17 @@
 	    <copy attributes="role" css:content="content" css:theme="contentspace" />
         <replace css:content="#portal-column-one" css:theme="#portal-column-one" />
         <replace css:content="#viewlet-above-content" css:theme="#viewlet-above-content" />
-        <replace content="//*[@id='portal-column-content']/div[2]" theme="//*[@id='portal-column-content']/div[1]" />
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        
+        <!-- Devem ser selecionados os filhos imediátos do #portal-column-content do conteúdo, para
+        que não sejam aplicados em templates que não sejam de gestão de usuários. Se as regras abaixo
+        forem aplicadas em templates que não sejam de gestão de usuários, o conteúdo ficará duplicado uma vez que a regra:
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        já insere esses ids no tema.-->
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #kssPortalMessage" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #dashboard-info-message" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #content" />
+
         <copy attributes="class" css:content="#portal-column-content" css:theme="#portal-column-content" />
         <replace css:content="#portal-column-content > #viewlet-below-content" css:theme="#portal-column-content > #viewlet-below-content" />
         <replace css:content="#portal-column-two" css:theme="#portal-column-two" />

--- a/src/brasil/gov/temas/themes/branco/index.html
+++ b/src/brasil/gov/temas/themes/branco/index.html
@@ -304,7 +304,7 @@
             <div id="portal-column-content" class="cell width-1:2 position-1:4">
                 <a name="acontent" id="acontent"></a>
 
-                <div class="">
+                <div id="main-content" class="">
 
                     <div id="content">
 

--- a/src/brasil/gov/temas/themes/branco/rules.xml
+++ b/src/brasil/gov/temas/themes/branco/rules.xml
@@ -37,7 +37,17 @@
 	    <copy attributes="role" css:content="content" css:theme="contentspace" />
         <replace css:content="#portal-column-one" css:theme="#portal-column-one" />
         <replace css:content="#viewlet-above-content" css:theme="#viewlet-above-content" />
-        <replace content="//*[@id='portal-column-content']/div[2]" theme="//*[@id='portal-column-content']/div[1]" />
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        
+        <!-- Devem ser selecionados os filhos imediátos do #portal-column-content do conteúdo, para
+        que não sejam aplicados em templates que não sejam de gestão de usuários. Se as regras abaixo
+        forem aplicadas em templates que não sejam de gestão de usuários, o conteúdo ficará duplicado uma vez que a regra:
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        já insere esses ids no tema.-->
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #kssPortalMessage" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #dashboard-info-message" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #content" />
+
         <copy attributes="class" css:content="#portal-column-content" css:theme="#portal-column-content" />
         <replace css:content="#portal-column-content > #viewlet-below-content" css:theme="#portal-column-content > #viewlet-below-content" />
         <replace css:content="#portal-column-two" css:theme="#portal-column-two" />

--- a/src/brasil/gov/temas/themes/verde/index.html
+++ b/src/brasil/gov/temas/themes/verde/index.html
@@ -304,7 +304,7 @@
             <div id="portal-column-content" class="cell width-1:2 position-1:4">
                 <a name="acontent" id="acontent"></a>
 
-                <div class="">
+                <div id="main-content" class="">
 
                     <div id="content">
 

--- a/src/brasil/gov/temas/themes/verde/rules.xml
+++ b/src/brasil/gov/temas/themes/verde/rules.xml
@@ -37,7 +37,17 @@
 	    <copy attributes="role" css:content="content" css:theme="contentspace" />
         <replace css:content="#portal-column-one" css:theme="#portal-column-one" />
         <replace css:content="#viewlet-above-content" css:theme="#viewlet-above-content" />
-        <replace content="//*[@id='portal-column-content']/div[2]" theme="//*[@id='portal-column-content']/div[1]" />
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        
+        <!-- Devem ser selecionados os filhos imediátos do #portal-column-content do conteúdo, para
+        que não sejam aplicados em templates que não sejam de gestão de usuários. Se as regras abaixo
+        forem aplicadas em templates que não sejam de gestão de usuários, o conteúdo ficará duplicado uma vez que a regra:
+        <replace content="//*[@id='portal-column-content']/div[2]" css:theme="#main-content" />
+        já insere esses ids no tema.-->
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #kssPortalMessage" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #dashboard-info-message" />
+        <before css:theme="#viewlet-below-content" css:content="#portal-column-content > #content" />
+
         <copy attributes="class" css:content="#portal-column-content" css:theme="#portal-column-content" />
         <replace css:content="#portal-column-content > #viewlet-below-content" css:theme="#portal-column-content > #viewlet-below-content" />
         <replace css:content="#portal-column-two" css:theme="#portal-column-two" />

--- a/travis.cfg
+++ b/travis.cfg
@@ -14,3 +14,8 @@ parts +=
 
 [code-analysis]
 directory = src
+
+[versions]
+# Necessário colocar o pacote com versão vazia para que outras versões no
+# buildout-cache não sobrescrevam o próprio pacote.
+brasil.gov.temas =

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,10 +1,10 @@
 [versions]
 # XXX: needed by plone.app.event in brasil.gov.portal
-plone.app.portlets = 2.5a1
+plone.app.portlets = 2.4.8
 # XXX: needed by brasil.gov.agenda in brasil.gov.portal
 plone.dexterity = 2.2.3
 # XXX: needed by z3c.unconfigure in brasil.gov.portal
-zope.configuration = 3.8.0
+zope.configuration = 3.8.1
 
 # XXX: Versão 3.3.1 de collective.js.bootstrap passa a pedir como dependência
 # plone.app.jquery>=1.8.3, dando conflito no release do Plone 4.3.x.
@@ -20,3 +20,8 @@ python-oembed = 0.2.1
 # XXX: collective.nitf 1.0b5 pede o plone.app.querystring>=1.2.5.
 # Discussão em: https://github.com/plonegovbr/brasil.gov.tiles/issues/126
 plone.app.querystring = 1.2.5
+
+# XXX: plone.app.theming = 1.1.3 causa erro:
+# ConfigurationExecutionError: <class 'zope.component.interfaces.ComponentLookupError'>:
+# (<InterfaceClass zope.security.interfaces.IPermission>, 'plone.app.controlpanel.Themes')
+plone.app.theming = 1.1.1


### PR DESCRIPTION
O problema era que as telas 'Preferências Pessoais', 'Informação Pessoal' e 'Painel Pessoal' utilizam um template diferente do main_template. Isso corrigie https://github.com/plonegovbr/brasil.gov.temas/issues/113

@hvelarde você pode revisar por favor?