### PR TITLE
Melhorar a estrutura de testes de dependências em futuros releases, evitando que muitos erros só apareçam quando é lançado o release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 python: 2.7
+sudo: false
+cache:
+  directories:
+  - eggs
+  - parts/node
 env:
   matrix:
     - MASTER=true
@@ -12,19 +17,18 @@ install:
 - test $MASTER && sed -ie '/https:\/\/raw\.githubusercontent\.com\/plonegovbr\/portal\.buildout\/master\/buildout\.d\/versions\.cfg/d' buildout.cfg || true
 - python bootstrap.py
 - bin/buildout annotate
-- bin/buildout -Nq
+- bin/buildout
 before_script:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+- export DISPLAY=:99.0
+- sh -e /etc/init.d/xvfb start
+- firefox -v
 script:
 - bin/code-analysis
 - bin/test
 after_success:
-  - bin/coverage.sh
-  - pip install -q coveralls
-  - coveralls
-after_failure:
-  - bin/buildout annotate
-  - firefox -v
+- bin/createcoverage -t "--layer=!Acceptance"
+- pip install -q coveralls
+- coveralls
 notifications:
   irc: irc.freenode.org#plonegovbr
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: python
 python: 2.7
+env:
+  matrix:
+    - MASTER=true
+    - PENDING_RELEASE=true
+matrix:
+  allow_failures:
+    - env: MASTER=true
+  fast_finish: true
 install:
-  - python bootstrap.py
-  - bin/buildout annotate
-  - bin/buildout -Nq
+- test $MASTER && sed -ie '/https:\/\/raw\.githubusercontent\.com\/plonegovbr\/portal\.buildout\/master\/buildout\.d\/versions\.cfg/d' buildout.cfg || true
+- python bootstrap.py
+- bin/buildout annotate
+- bin/buildout -Nq
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,7 +2,7 @@
 extends =
     https://raw.github.com/collective/buildout.plonetest/master/test-4.3.x.cfg
     https://raw.github.com/collective/buildout.plonetest/master/qa.cfg
-    https://raw.githubusercontent.com/plonegovbr/portalpadrao.release/master/1.1.4/versions.cfg
+    https://raw.githubusercontent.com/plone/plone.app.robotframework/master/versions.cfg
     https://raw.githubusercontent.com/plonegovbr/portal.buildout/master/buildout.d/versions.cfg
 
 package-name = brasil.gov.temas


### PR DESCRIPTION
Pacotes plonegovbr deveriam ter mais de um job de testes : plonegovbr/portalpadrao.release#11