### PR TITLE
plone.app.contenttypes usada pelo Plone (1.1.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,12 @@ before_script:
 script:
 - bin/code-analysis
 - bin/test
+after_script:
+# XXX:
+# Firefox reclama: GConf-WARNING **: Got Disconnected from DBus.
+# E continua falhndo, criando um job falho a cada 30-50 minutos.
+# Então simplesmente matamos o processo.
+- pkill -9 firefox
 after_success:
 - bin/createcoverage -t "--layer=!Acceptance"
 - pip install -q coveralls

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Histórico de Alterações
 1.3 (unreleased)
 ^^^^^^^^^^^^^^^^
 
-- Nothing changed yet.
+- Remove plone.app.contenttypes de dependência.
+  [idgserpro]
 
 
 1.2 (2016-11-07)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ long_description = (
 setup(
     name='brasil.gov.temas',
     version=version,
-    description="Temas para o Portal PadrÄĹo do Governo Federal",
+    description="Temas para o Portal Padrão do Governo Federal",
     long_description=long_description,
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -47,7 +47,6 @@ setup(
         'Products.CMFPlone >=4.3',
         'setuptools',
         'plone.app.themingplugins',
-        'plone.app.contenttypes<1.1a1',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
O pacote brasil.gov.temas não faz nenhuma referência ao
plone.app.contenttypes, essa pinagem aqui não faz sentido.

Esse commit é necessário para prosseguirmos com

https://github.com/plonegovbr/brasil.gov.portal/issues/240

Logo após a aprovação do PR, um release pode ser efetuado imediatamente e será pinado em portal.buildout para o próximo release.