### PR TITLE
Estilos para capa com cor de fundo destacada

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Changelog
     Este release atualiza as dependências do processamento de recursos estáticos.
     Em ambiente de desenvolvimento pode ser necessário remover as pastas ``parts`` e ``webpack/node_modules`` para efetivar a atualização de ambiente.
 
+- Estilos para capa com cor de fundo destacada.
+  [agnogueira]
+
 - Corrige largura do tile de navegação.
   [agnogueira]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,8 @@ Changelog
     Este release atualiza as dependências do processamento de recursos estáticos.
     Em ambiente de desenvolvimento pode ser necessário remover as pastas ``parts`` e ``webpack/node_modules`` para efetivar a atualização de ambiente.
 
-- Estilos para capa com cor de fundo destacada.
+- Estilos iniciais para permitir a utilização de uma capa com fundo colorido.
+  Para que o estilo funcione, o usuário deve criar um modelo de capa com o nome "Capa fundo destacado".
   [agnogueira]
 
 - Corrige largura do tile de navegação.

--- a/webpack/app/scss/_tiles.scss
+++ b/webpack/app/scss/_tiles.scss
@@ -935,3 +935,37 @@ header.inverter .search-wrapper {
         color: #fff!important;    
     }
 }
+
+/* Capa Colorida */
+body.cover-layout-capa-fundo-destacado {
+  background-color: #2969bd;
+  color: #fff;
+
+  #portal-breadcrumbs {
+    border-bottom: 1px solid rgba(256,256,256,.2);
+    color: #fff;
+  }
+  #portal-breadcrumbs a, 
+  #portal-breadcrumbs a:hover,
+  a:link,   a:visited,
+  h1, h2, h3, h4,
+  .tile .outstanding-header h1,
+  .tile .outstanding-header h2 {
+    color: #fff;
+  }
+  .breadcrumbSeparator,
+  #portal-breadcrumbs #breadcrumbs-home a:before,
+  .voltar-topo a:after {
+    filter: invert(100%);
+  }
+  .layout .cover-tile {
+    background-color: #2969bd;
+  }
+  .tiles-configuration,
+  .tiles-configuration h1,
+  footer h3,
+  .pb-ajax,
+  .pb-ajax h1 {
+    color: #000 !important;
+  }
+}


### PR DESCRIPTION
Estilos iniciais para permitir a utilização de uma capa com fundo colorido.
Para que o estilo funcione, o usuário deve criar um modelo de capa com o nome "Capa fundo destacado"