### PR TITLE
Controle para degrade no topo

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 2.0b3 (unreleased)
 ^^^^^^^^^^^^^^^^^^
 
+- Adiciona estilo para controlar degrade do destaque topo
+  [agnogueira]
+
 - Altera a cor de fundo básica dos temas
   [agnogueira]
 

--- a/webpack/app/scss/_tiles.scss
+++ b/webpack/app/scss/_tiles.scss
@@ -657,7 +657,6 @@ p.tile-description {
 }
 .portaltype-collective-cover-content.template-view div.row.linha-destaquetopo .tile::before {
     background-color: transparent;
-
     content: " ";
     white-space: nowrap;
     display: block;

--- a/webpack/app/scss/_tiles.scss
+++ b/webpack/app/scss/_tiles.scss
@@ -657,10 +657,7 @@ p.tile-description {
 }
 .portaltype-collective-cover-content.template-view div.row.linha-destaquetopo .tile::before {
     background-color: transparent;
-    background-image:
-    radial-gradient(
-      transparent, #000
-    );
+
     content: " ";
     white-space: nowrap;
     display: block;
@@ -673,6 +670,12 @@ p.tile-description {
     opacity: .8;
     z-index: -1;
     text-indent: -3000px;
+}
+.portaltype-collective-cover-content.template-view div.row.linha-destaquetopo.topo-com-degrade .tile::before {
+    background-image:
+    radial-gradient(
+      transparent, #000
+    );
 }
 .portaltype-collective-cover-content.template-view div.row.linha-destaquetopo .tile.foto-destacada-grande::before {
     height: 802px;


### PR DESCRIPTION
Remove degrade por padrão do destaque topo.
Cria estilo que permite adicionar o desgrade quando necessário